### PR TITLE
Allow other Account Management's write-activity-log function to encrypt using this key

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -85,6 +85,12 @@ Resources:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
             Action: "kms:*"
             Resource: "*"
+          - Sid: "Allow Account Management's write-activity-log function to encrypt using this key"
+            Effect: Allow
+            Action: "kms:Encrypt"
+            Resource: "*"
+            Principal:
+              AWS: !Sub '{{resolve:ssm:/${AWS::StackName}/${Environment}/AccountManagement/Backend/WriteActivityRecordRole}}'
       Tags:
         - Key: Product
           Value: !Ref ProductTagValue
@@ -112,4 +118,3 @@ Resources:
       Name: !Sub "/${AWS::StackName}/${Environment}/AccountManagement/Backend/WriteActivityRecordRole"
       Type: String
       Value: "arn:aws:iam::<fill-in-account-id>:role/account-mgmt-backend-WriteActivityRecordRole-<fill-in-account-id>"
-      

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -104,3 +104,12 @@ Resources:
     Properties:
       AliasName: !Sub "alias/${AWS::StackName}-BackupWrapperKey"
       TargetKeyId: !GetAtt BackupWrapperKey.Arn
+
+  AccountManagementBackendWriteActivityLogRoleSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "Root ARN of the acctount-management-backend AWS account"
+      Name: !Sub "/${AWS::StackName}/${Environment}/AccountManagement/Backend/WriteActivityRecordRole"
+      Type: String
+      Value: "arn:aws:iam::<fill-in-account-id>:role/account-mgmt-backend-WriteActivityRecordRole-<fill-in-account-id>"
+      


### PR DESCRIPTION
DON"T MERGE BEFORE:
1. this PR has been merged https://github.com/alphagov/di-account-data-backend/pull/6
2. placeholder SSM values have been replaced with real values


This KeyPolicy update allows the write-activity-log function to encrypt using this key.